### PR TITLE
+ naming convention for backend.

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,11 @@ Status codes for common escenarious:
 
 * Force update:
     - `412`: If the user have an app version that should be updated.    
+    - 
+    - 
+    - 
+
+Naming Convention
+------------------
+
+* Parameters: lower case with _ as divider like: `first_name`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,4 +19,4 @@ Status codes for common escenarious:
 Naming Convention
 ------------------
 
-* Parameters: lower case with _ as divider like: `first_name`.
+* Variables: lower case with - as divider like: `first-name`.


### PR DESCRIPTION
The idea is to avoid having some endpoints with different param name conventions.
