### PR TITLE
Add client version convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code styles, and tools for different languages
 
   * `bv-app-version`: `platform/typeApp/version/build` (***each value separated by a `/`***) _where_:
 
-    - `platform` :***mandatory*** platform who make the request in lower case (ej: ios, android)
-    - `typeApp` :***mandatory*** app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
-    - `version` :***mandatory*** current app version following semver standard (x.y.z)
-    - `build` :***optional*** current build version, could be number or letters
+    - `platform` :***(mandatory)*** platform who make the request in lower case (ej: ios, android)
+    - `typeApp` :***(mandatory)*** app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
+    - `version` :***(mandatory)*** current app version following semver standard (x.y.z)
+    - `build` :***(optional)*** current build version, could be number or letters

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code styles, and tools for different languages
 
   * `bv-app-version`: `platform/typeApp/version/build` (***each value separated by a `/`***) _where_:
 
-    - `platform` :***(mandatory)*** platform who make the request in lower case (ej: ios, android)
-    - `typeApp` :***(mandatory)*** app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
-    - `version` :***(mandatory)*** current app version following semver standard (x.y.z)
-    - `build` :***(optional)*** current build version, could be number or letters
+    - `platform`***(mandatory)*** : platform who make the request in lower case (ej: ios, android)
+    - `typeApp`***(mandatory)*** : app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
+    - `version`***(mandatory)*** : current app version following semver standard (x.y.z)
+    - `build`***(optional)*** : current build version, could be number or letters

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Code styles, and tools for different languages
     - `platform` : platform who make the request in lower case (ej: ios, android)
     - `typeApp` : app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
     - `version` : current app version following semver standard (x.y.z)
-    - `build : current build version, could be empty, number or letters
+    - `build` : current build version, could be empty, number or letters

--- a/README.md
+++ b/README.md
@@ -3,4 +3,11 @@ Code styles, and tools for different languages
 
 # General conventions
 
-- Mobile Clients will send a header `bv-app-version` with the app version for each api request.
+- Mobile Clients should always send the next headers for every request with our api: 
+
+  * `bv-app-version`: `platform/typeApp/version/build` _where_:
+  
+    - `platform` : platform who make the request in lower case (ej: ios, android)
+    - `typeApp` : app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
+    - `version` : current app version following semver standard (x.y.z)
+    - `build : current build version, could be empty, number or letters

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Code styles, and tools for different languages
 
 # General conventions
 
-- Clients should send the next headers on every request to our api: 
+- Clients should send the next headers on every request to our api:
 
-  * `bv-app-version`: `platform/typeApp/version/build` _where_:
-  
-    - `platform` : platform who make the request in lower case (ej: ios, android)
-    - `typeApp` : app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
-    - `version` : current app version following semver standard (x.y.z)
-    - `build` : current build version, could be empty, number or letters
+  * `bv-app-version`: `platform/typeApp/version/build` (***each value separated by a `/`***) _where_:
+
+    - `platform` :***mandatory*** platform who make the request in lower case (ej: ios, android)
+    - `typeApp` :***mandatory*** app profile who make the request in lower case (ej: customer, driver, admin) if there are only one app could be mobile for mobile apps
+    - `version` :***mandatory*** current app version following semver standard (x.y.z)
+    - `build` :***optional*** current build version, could be number or letters

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Code styles, and tools for different languages
 
 # General conventions
 
-- Mobile Clients should always send the next headers for every request with our api: 
+- Clients should send the next headers on every request to our api: 
 
   * `bv-app-version`: `platform/typeApp/version/build` _where_:
   

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # code_style
 Code styles, and tools for different languages
+
+# General conventions
+
+- Mobile Clients will send a header `bv-app-version` with the app version for each api request.


### PR DESCRIPTION
Should we send the same header on each app or a new header based on app name?
