### PR TITLE
Propose format to backend dates

### DIFF
--- a/backend/API_standards.md
+++ b/backend/API_standards.md
@@ -236,7 +236,8 @@ Servers have to be configured to centralize logs on Papertrail.
 ## Other topics
 
 ### Date/time timezones handling
-`Date` data types should be avoided, all data should be persisted along with the timezone, to avoid possible issues with the API consumers timezone conversions.
+- Send/recieve dates as strings with ISO format: `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.
+- `Date` data types should be avoided, all data should be persisted along with the timezone, to avoid possible issues with the API consumers timezone conversions.
 
 ## Internationalization
 Internationalization would be handled by the API, all messages should be sent in the appropriates language for the authenticated user.


### PR DESCRIPTION
We already use this format in the other apps

```
yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
```

The idea is to always send/receive dates in that format.