### PR TITLE
Add code comment for private access code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,9 @@ Use "[APP][FILE][METHOD]" as log tag or prefix for each `log.print`.
 
 Example:
 > [Sniffle][SubscriptionController][getSubscriptions] something happened in here.
+
+## Code Comments
+
+Do not comment private functions/attributes [detekt/comments](https://arturbosch.github.io/detekt/comments.html#commentoverprivatefunction) because function name should be self explanatory.
+
+Use comments only when necesary.


### PR DESCRIPTION
Ideas from https://arturbosch.github.io/detekt/comments.html#commentoverprivatefunction:

> This rule reports comments and documentation that has been added to private functions. These comments get reported because they probably explain the functionality of the private function. However private functions should be small enough and have an understandable name so that they are self-explanatory and do not need this comment in the first place.

> Instead of simply removing this comment to solve this issue prefer to split up the function into smaller functions with better names if necessary. Giving the function a better, more descriptive name can also help in solving this issue.

The link is from an automatic Kotlin style checker... but may help to start with this ideas